### PR TITLE
update clusterNodes , add namespace "skywalking"

### DIFF
--- a/6/6.0.0-GA/oap/01-config.yml
+++ b/6/6.0.0-GA/oap/01-config.yml
@@ -45,7 +45,7 @@ data:
         monthMetricsDataTTL: 18 # Unit is month
     storage:
       elasticsearch:
-        clusterNodes: elasticsearch:9200
+        clusterNodes: elasticsearch.skywalking:9200
         indexShardsNumber: 2
         indexReplicasNumber: 0
         bulkActions: 2000 # Execute the bulk every 2000 requests

--- a/6/6.0.0-alpha/oap/01-config.yml
+++ b/6/6.0.0-alpha/oap/01-config.yml
@@ -45,7 +45,7 @@ data:
         monthMetricsDataTTL: 18 # Unit is month
     storage:
       elasticsearch:
-        clusterNodes: elasticsearch:9200
+        clusterNodes: elasticsearch.skywalking:9200
         indexShardsNumber: 2
         indexReplicasNumber: 0
         bulkActions: 2000 # Execute the bulk every 2000 requests

--- a/6/6.0.0-beta/oap/01-config.yml
+++ b/6/6.0.0-beta/oap/01-config.yml
@@ -45,7 +45,7 @@ data:
         monthMetricsDataTTL: 18 # Unit is month
     storage:
       elasticsearch:
-        clusterNodes: elasticsearch:9200
+        clusterNodes: elasticsearch.skywalking:9200
         indexShardsNumber: 2
         indexReplicasNumber: 0
         bulkActions: 2000 # Execute the bulk every 2000 requests


### PR DESCRIPTION
The elasticsearch service should be connected by  "service_name . namespace : port" in kubernetes.
So the oap's config element clusterNodes should add namespace "skywalking" 